### PR TITLE
opts.moveTo for update()

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ If you provide the terminal width ansi-diff will be able to support word wrappin
 done by the terminal. That means that if you print out a line that is too long to fit in the terminal
 the diff will still work.
 
-#### `var changes = diff.update(buffer)`
+#### `var changes = diff.update(buffer, opts)`
 
 Update the buffer and return the diff between this and the previous one.
 The diff is returned in ANSI as a buffer so you can write it out to the terminal.
+
+* `opts.moveTo` - array of `[column,row]` to move the cursor after diffing the
+  screen (in absolute coordinates)
 
 #### `diff.resize([options])`
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ Diff.prototype.toString = function () {
   return this._buffer
 }
 
-Diff.prototype.update = function (buffer) {
+Diff.prototype.update = function (buffer, opts) {
   this._buffer = Buffer.isBuffer(buffer) ? buffer.toString() : buffer
 
   var other = this._buffer
@@ -101,7 +101,9 @@ Diff.prototype.update = function (buffer) {
     this._clearDown(oldLast.y + oldLast.height)
   }
 
-  if (last) {
+  if (opts && opts.moveTo) {
+    this._moveTo(opts.moveTo[0], opts.moveTo[1])
+  } else if (last) {
     this._moveTo(last.remainder, last.y + last.height)
   }
 


### PR DESCRIPTION
With this patch, you can set the final cursor position after diffing the screen. Otherwise, the cursor is always at the end of the screen.