### PR TITLE
Add Unicode support

### DIFF
--- a/example.js
+++ b/example.js
@@ -15,8 +15,10 @@ function onresize () {
 }
 
 function render () {
+  const even = Math.floor(Date.now()/1000) % 2 == 0
   var message =
-    'This is a demo\n' +
+    `This is a demo\n` +
+    `|${even ? 'ヤニコード' : '          '}|\n` +
     'The time is: ' + new Date() + '\n' +
     'That is all\n'
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var ansi = require('ansi-split')
+var wcwidth = require('wcwidth')
 
 var CLEAR_LINE = Buffer.from([0x1b, 0x5b, 0x30, 0x4b])
 var NEWLINE = Buffer.from('\n')
@@ -236,7 +237,7 @@ function moveLeft (n) {
 function length (parts) {
   var len = 0
   for (var i = 0; i < parts.length; i += 2) {
-    len += parts[i].length
+    len += wcwidth(parts[i])
   }
   return len
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A module that diffs an input buffer with the previous one provided to it and outputs the diff as ANSI",
   "main": "index.js",
   "dependencies": {
-    "ansi-split": "^1.0.1"
+    "ansi-split": "^1.0.1",
+    "wcwidth": "^1.0.1"
   },
   "devDependencies": {
     "standard": "^10.0.3"


### PR DESCRIPTION
This utilizes the `wcwidth` module to compute the visual width of Unicode code points in a terminal setting (fixed-width font). The default example is also modified to demonstrate this.

I still don't fully understand how this module works, but my edit fixes Unicode-related issues downstream (in [cabal-cli](https://github.com/cabal-club/cabal-cli)).

@mafintosh I'm not sure if you're still maintaining this module. If not, please let me know so I can depend on a fork instead. Thanks friend!